### PR TITLE
[project.py] set yolo settings dependent on registry

### DIFF
--- a/kso_utils/project.py
+++ b/kso_utils/project.py
@@ -1644,7 +1644,10 @@ class MLProjectProcessor(ProjectProcessor):
         img_size: int = 128,
     ):
         # Disable wandb (not necessary yet)
-        self.modules["ultralytics"].settings.update({"wandb": True})
+        if self.registry == "wandb":
+            self.modules["ultralytics"].settings.update({"wandb": True})
+        elif self.registry == "mlflow":
+            self.modules["ultralytics"].settings.update({"mlflow": True})
 
         if self.registry == "mlflow":
             active_run = mlflow.active_run()
@@ -1662,8 +1665,6 @@ class MLProjectProcessor(ProjectProcessor):
             val_dataset: PandasDataset = mlflow.data.from_pandas(
                 val_df, source=valid_path
             )
-            # if active_run:
-            #    mlflow.end_run()
 
             from mlflow.exceptions import MlflowException
 
@@ -1745,6 +1746,8 @@ class MLProjectProcessor(ProjectProcessor):
         # Close down run
         if self.registry == "wandb":
             self.modules["wandb"].finish()
+        elif self.registry == "mlflow":
+            mlflow.end_run()
 
     def train_yolov5(
         self, exp_name, weights, project, epochs=50, batch_size=16, img_size=[640, 640]


### PR DESCRIPTION
We want to track the training process either with WandB or with MLflow. Yolo from Ultralytics has build in support for both. But to use the tracking with that platform, you need to set the settings for that platform to True.
See Ultralytics documentation:
https://github.com/ultralytics/ultralytics/blob/21162bd870444550286983a601afbfb142f4c198/docs/en/integrations/mlflow.md

I don't understand how the code could have worked together with MLflow before, since I think that this was missing.
However, that we always set this setting to WandB explains why we always got WandB information in the printed output of the training, even when we tried to use MLflow.

I think that this change should fix issue #444.