### PR TITLE
Fix CI job building container images

### DIFF
--- a/.github/actions/increase-docker-space/action.yml
+++ b/.github/actions/increase-docker-space/action.yml
@@ -41,6 +41,8 @@ runs:
         mount --bind /mnt/docker /var/lib/docker
         EOF
 
+    # This fix was last tested in November 2025.
+    # If enabled later again, the list of removed paths might need to be updated.
     # We skip this erasing step to speed up the CI run.
     # If /mnt disappears at some point from the runner, you can gain disk space by enabling this.
     # See https://github.com/actions/runner-images/blob/0d358721aff04547ce591c7e1c444dc285fae993/images/ubuntu/Ubuntu2404-Readme.md
@@ -55,6 +57,8 @@ runs:
         rm -rf "$CONDA"                 #  1 GB
         EOF
 
+    # This fix was last tested in November 2025.
+    # If enabled later again, the list of removed packages might need to be updated.
     # We skip this erasing step to speed up the CI run.
     # If /mnt disappears at some point from the runner, you can gain disk space by enabling this.
     # See https://github.com/actions/runner-images/blob/0d358721aff04547ce591c7e1c444dc285fae993/images/ubuntu/Ubuntu2404-Readme.md

--- a/.github/actions/increase-docker-space/action.yml
+++ b/.github/actions/increase-docker-space/action.yml
@@ -9,10 +9,25 @@ runs:
       run: |
         df -h
 
-    # In the github runner, /mnt is mounted to some other volume with plenty of free space.
-    # We move the docker directory to this volume to have enough space for building images.
+    # Currently (February 2026), github runners have 92G or 23G free space on /.
+    # In the first case, no fixes are needed as there is enough space.
+    # In the second case, the runner has /mnt mounted to some other volume with 66G free space.
+    # Let's start by checking which kind of runner we got.
+    - name: Check if /mnt is mounted
+      id: mntcheck
+      shell: bash
+      run: |
+        if grep -qE '[[:space:]]/mnt[[:space:]]' /proc/mounts; then
+          echo "mounted=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "mounted=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # If /mnt was mounted, then we don't likely have enough free space on /, so
+    # we move the docker directory to /mnt to have enough space for building images.
     # This is much faster than erasing files to free disk space
     - name: Move docker directory
+      if: steps.mntcheck.outputs.mounted == 'true'
       shell: bash
       run: |
         echo "---- Contents of /mnt -------------"


### PR DESCRIPTION
This PR will fix failing CI jobs (example [here](https://github.com/ocean-data-factory-sweden/kso/actions/runs/21716116292/job/62632512584?pr=488)). It seems that there are two kinds of runners: some have enough free space on `/` and some need fixes.

Some github runners have these file systems:
```raw
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   53G   92G  37% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G 1000K  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   32K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      881M   62M  758M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

And some have these:
```raw
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   50G   23G  70% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   32K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      881M   62M  758M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
/dev/sdb1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

This PR will apply fixes only to the latter case.