### PR TITLE
fix: initialise preview_path before conditional block (lint E0601)

### DIFF
--- a/notebooks/analyse/Model_Inference.ipynb
+++ b/notebooks/analyse/Model_Inference.ipynb
@@ -214,6 +214,8 @@
     "    # ── Preview setup (first video only) ──\n",
     "    preview_writer = None\n",
     "    preview_limit = 0\n",
+    "    preview_path = None\n",
+    "    preview_fps = None\n",
     "    if PREVIEW_SECONDS > 0 and not preview_done:\n",
     "        preview_dir = output_dir / \"preview\"\n",
     "        preview_dir.mkdir(exist_ok=True)\n",


### PR DESCRIPTION
Small one line fix - the variable was only assigned inside the if PREVIEW_SECONDS > 0 block but referenced later in the loop. Will monitor the checks more