### PR TITLE
Run CI workflows on all branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 on:
   push:
     branches:
-      - "*"
+      - "**"
     tags:
       - "v*.*.*"
   workflow_dispatch:

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -3,7 +3,7 @@ name: Code formatting
 on:
   push:
     branches:
-      - "*"
+      - "**"
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This PR will update CI workflow branch targets from `*` to `**` in order to trigger workflows on branch names with slashes (for example #511).