### PR TITLE
Fix local use of container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,20 @@ For local use without HPC access. Training without a GPU will be slow; smaller m
 
 **Docker**
 
-> **⚠️ Note:** The Docker image may not be up to date with the current codebase. Verify it works for your use case before relying on it.
-
 ```bash
-docker pull ghcr.io/ocean-data-factory-sweden/kso:dev
-docker run --gpus all -it -p 8888:8888 ghcr.io/ocean-data-factory-sweden/kso:dev
-# Then open http://localhost:8888 in your browser
+# Pull kso with a suitable backend
+docker pull ghcr.io/ocean-data-factory-sweden/kso:dev-ubuntu24.04             # CPU only
+# docker pull ghcr.io/ocean-data-factory-sweden/kso:dev-cuda12.9-ubuntu24.04  # CUDA / NVIDIA GPUs
+# docker pull ghcr.io/ocean-data-factory-sweden/kso:dev-rocm6.4-ubuntu24.04   # ROCm / AMD GPUs
+
+# Run the notebooks
+docker run -it --rm -p 8888:8888 ghcr.io/ocean-data-factory-sweden/kso:dev-ubuntu24.04 notebooks/
+# docker run -it --rm -p 8888:8888 --gpus all ghcr.io/ocean-data-factory-sweden/kso:dev-cuda12.9-ubuntu24.04 notebooks/
+# docker run -it --rm -p 8888:8888 --device /dev/kfd --device /dev/dri ghcr.io/ocean-data-factory-sweden/kso:dev-rocm6.4-ubuntu24.04 notebooks/
+
+# Then open http://localhost:8888 in your browser and use the token printed out
 ```
+
 **pip**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ For local use without HPC access. Training without a GPU will be slow; smaller m
 
 **Docker**
 
+Note: The instructions below run the notebooks inside the container.
+Any changes you make will be lost when the container stops unless you save them outside the container (e.g., using a mounted volume).
+
 ```bash
 # Pull kso with a suitable backend
 docker pull ghcr.io/ocean-data-factory-sweden/kso:dev-ubuntu24.04             # CPU only

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ For local use without HPC access. Training without a GPU will be slow; smaller m
 **Docker**
 
 Note: The instructions below run the notebooks inside the container.
-Any changes you make will be lost when the container stops unless you save them outside the container (e.g., using a mounted volume).
+Any changes you make will be lost when the container stops unless you save them outside the container
+(e.g., using a mounted volume: `-v $(pwd):/opt/kso/notebooks`).
 
 ```bash
 # Pull kso with a suitable backend

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec jupyter lab --ip=0.0.0.0 --no-browser "$@"

--- a/containers/final/Dockerfile
+++ b/containers/final/Dockerfile
@@ -19,3 +19,6 @@ RUN adduser --disabled-password \
 USER ${NB_USER}
 
 WORKDIR /opt/kso
+
+ENTRYPOINT ["/opt/kso/containers/entrypoint.sh"]
+CMD []

--- a/containers/final/Dockerfile
+++ b/containers/final/Dockerfile
@@ -16,6 +16,7 @@ RUN adduser --disabled-password \
 
 # Copy KSO
 COPY --chown=${NB_UID}:${NB_UID} . /opt/kso
+RUN chmod +x /opt/kso/containers/entrypoint.sh
 
 # Set run environment
 USER ${NB_USER}

--- a/containers/final/Dockerfile
+++ b/containers/final/Dockerfile
@@ -1,9 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/ocean-data-factory-sweden/kso-base:latest
 FROM ${BASE_IMAGE}
 
-# Copy KSO
-COPY . /opt/kso
-
 # Set the user
 ARG NB_USER=jovyan
 ARG NB_UID=1500
@@ -16,9 +13,12 @@ RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
+
+# Copy KSO
+COPY --chown=${NB_UID}:${NB_UID} . /opt/kso
+
+# Set run environment
 USER ${NB_USER}
-
 WORKDIR /opt/kso
-
 ENTRYPOINT ["/opt/kso/containers/entrypoint.sh"]
 CMD []


### PR DESCRIPTION
This PR will update the instructions for running the container images locally and set jupyter as the default entrypoint for them.

Closes #504.