### PR TITLE
feat(notebooks): add 01_Project_Setup notebook for KSO2 pipeline

### DIFF
--- a/notebooks/01_Project_Setup.ipynb
+++ b/notebooks/01_Project_Setup.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "<img align=\"right\" src=\"https://panoptes-uploads.zooniverse.org/project_avatar/86c23ca7-bbaa-4e84-8d8a-876819551431.png\" type=\"image/png\" height=100 width=100>\n",
+    "</img>\n",
+    "\n",
+    "# Project Setup\n",
+    "\n",
+    "**KSO2 Notebook 1 of 5** · Written by the KSO Team\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Create a KSO2 **project** and attach a **YOLO-formatted dataset** to it. The project is a folder that owns your experiment tracking (MLflow) and training runs. Datasets and base weights stay where they already live on disk; the project stores references to them.\n",
+    "\n",
+    "---\n",
+    "### Prerequisites\n",
+    "\n",
+    "- KSO2 installed. **LUMI users:** see [`contrib/lumi/README.md`](../contrib/lumi/README.md). **Local users:** `pip install -e .` from the repo root.\n",
+    "- A YOLO-formatted dataset ready, or skip ahead to use the built-in COCO8 sample for a quick test.\n",
+    "\n",
+    "> If you don't have a YOLO dataset yet, run **Notebook 0: Prepare Data** first to build one from raw footage or BIIGLE annotations.\n",
+    "\n",
+    "**What you'll do in this notebook:**\n",
+    "1. Create your project (generates `<name>.project.yaml` and the base folders)\n",
+    "2. Attach a YOLO dataset to it (your own `data.yaml`, or the built-in COCO8 sample)\n",
+    "3. *(Optional)* Run offline augmentation on the training set\n",
+    "4. Verify everything is ready for training\n",
+    "\n",
+    "**Next:** once complete, continue to **Notebook 2: Train and Evaluate Models**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Phase 0: Setup\n",
+    "\n",
+    "Import the managers and helpers used in this notebook. If you haven't installed KSO2 yet, see the **Prerequisites** above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import yaml\n",
+    "\n",
+    "from kso import ProjectManager, run_augmentation\n",
+    "\n",
+    "proj = ProjectManager()\n",
+    "\n",
+    "print(\" [OK] KSO2 imported successfully\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Phase 1: Create Project\n",
+    "\n",
+    "Choose a project name and a storage location. This creates a project folder containing a `<name>.project.yaml` config, an `mlflow.db` for experiment tracking, and a `runs/` folder for YOLO outputs.\n",
+    "\n",
+    "- `PROJECT_NAME` is sanitised (lowercased, non-alphanumeric characters become underscores). The sanitised version becomes your folder name.\n",
+    "- `PROJECT_PATH` is the parent directory.\n",
+    "\n",
+    "> Some paths in the YAML will show `None` at this stage. These get filled in as you progress through the notebooks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT_NAME = \"my_project_name\"  # <-- EDIT, for example \"MPA_Monitoring_2026\"\n",
+    "PROJECT_PATH = \"/path/to/parent/dir\"  # <-- EDIT, e.g. \"/scratch/project_/your_username\"\n",
+    "\n",
+    "project = proj.create_project(\n",
+    "    project_name=PROJECT_NAME,\n",
+    "    project_path=PROJECT_PATH,\n",
+    ")\n",
+    "\n",
+    "print(f\"\\n[OK] Project created\")\n",
+    "print(f\"  Name (sanitised): {project.project_name}\")\n",
+    "print(f\"  Config YAML:      {project.Config_file_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Phase 2: Attach Dataset\n",
+    "\n",
+    "Attach a YOLO-formatted dataset to the project. Point `DATA_YAML` at your `data.yaml`, or set it to `None` to use the built-in COCO8 sample.\n",
+    "\n",
+    "The dataset is not copied. The project YAML stores a reference to its `data.yaml`. If you later move the dataset, re-run this cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_YAML = \"/path/to/your/data.yaml\"  # <-- EDIT\n",
+    "# DATA_YAML = None   # use COCO8 sample instead\n",
+    "\n",
+    "proj.add_data(\n",
+    "    project=project,\n",
+    "    data_type=\"yolo_dataset\",\n",
+    "    data_path=DATA_YAML,\n",
+    ")\n",
+    "\n",
+    "print(\"Dataset attached:\", DATA_YAML if DATA_YAML else \"COCO8 sample\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Phase 3: Augmentation *(optional)*\n",
+    "\n",
+    "Generate flipped and rotated copies of your training images and labels on disk. Useful for very small datasets.\n",
+    "\n",
+    "Ultralytics already applies online augmentation during training, so this is a supplement, not a requirement. Skip this phase unless you have a specific reason to pre-augment.\n",
+    "> Each run draws a fresh random sample and writes new `_aug_*` files into `train/`. Repeated runs accumulate, they do not replace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RUN_AUGMENTATION = False  # <-- set to True to run\n",
+    "\n",
+    "if RUN_AUGMENTATION:\n",
+    "    run_augmentation(\n",
+    "        data_yaml_path=project.data_path[\"ultralytics_data_path\"],\n",
+    "        augment_factor=0.5,  # 0.5 adds ~50% more augmented images on top of originals\n",
+    "        random_seed=42,\n",
+    "    )\n",
+    "    print(\"\\n[OK] Augmentation complete\")\n",
+    "else:\n",
+    "    print(\"Skipped. Set RUN_AUGMENTATION = True above to enable.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Phase 4: Ready Check\n",
+    "\n",
+    "Confirm your dataset is reachable, splits are in place, and print the YAML path you'll pass to Notebook 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resolve the dataset path directly from the project object.\n",
+    "data_yaml_path = Path(project.data_path[\"ultralytics_data_path\"])\n",
+    "\n",
+    "is_sample = (\n",
+    "    \"default_dataset\" in str(data_yaml_path) or \"coco8\" in str(data_yaml_path).lower()\n",
+    ")\n",
+    "\n",
+    "if is_sample:\n",
+    "    print(f\"Project:      {project.project_name}\")\n",
+    "    print(f\"Dataset YAML: {data_yaml_path}\")\n",
+    "    print(\"Sample dataset attached. Splits will auto-download at training time.\")\n",
+    "else:\n",
+    "    with open(data_yaml_path, \"r\") as f:\n",
+    "        data_cfg = yaml.safe_load(f)\n",
+    "\n",
+    "    # In a YOLO data.yaml, `path` is relative to the YAML file's location.\n",
+    "    path_val = data_cfg.get(\"path\")\n",
+    "    data_root = (\n",
+    "        (data_yaml_path.parent / path_val).resolve()\n",
+    "        if path_val\n",
+    "        else data_yaml_path.parent\n",
+    "    )\n",
+    "    names = data_cfg[\"names\"]\n",
+    "    class_list = list(names.values()) if isinstance(names, dict) else names\n",
+    "\n",
+    "    print(f\"Project:      {project.project_name}\")\n",
+    "    print(f\"Dataset YAML: {data_yaml_path}\")\n",
+    "    print(f\"Classes ({len(class_list)}): {class_list}\")\n",
+    "    print()\n",
+    "\n",
+    "    IMG_EXTS = {\".jpg\", \".jpeg\", \".png\", \".tif\", \".tiff\", \".bmp\", \".webp\"}\n",
+    "    for split in [\"train\", \"val\", \"test\"]:\n",
+    "        split_rel = data_cfg.get(split)\n",
+    "        if not split_rel:\n",
+    "            print(f\"  {split:5s}: not defined\")\n",
+    "            continue\n",
+    "        split_dir = (data_root / split_rel).resolve()\n",
+    "        if not split_dir.exists():\n",
+    "            print(f\"  {split:5s}: MISSING -- {split_dir}\")\n",
+    "            continue\n",
+    "        n = sum(\n",
+    "            1\n",
+    "            for p in split_dir.iterdir()\n",
+    "            if p.is_file() and p.suffix.lower() in IMG_EXTS\n",
+    "        )\n",
+    "        print(f\"  {split:5s}: {n:5d} images  ({split_dir})\")\n",
+    "\n",
+    "print(\n",
+    "    f'\\n[OK] Ready. Use this in Notebook 2:\\n  YAML_PATH = \"{project.Config_file_path}\"'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Done\n",
+    "\n",
+    "Your project folder now contains:\n",
+    "\n",
+    "```\n",
+    "<PROJECT_PATH>/<project_name>/\n",
+    "|-- <project_name>.project.yaml   # config, pass this to Notebook 2\n",
+    "|-- mlflow.db                     # experiment tracking (populated during training)\n",
+    "`-- runs/                         # YOLO training outputs (populated during training)\n",
+    "```\n",
+    "\n",
+    "Continue to **Notebook 2: Train and Evaluate Models**."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds 01_Project_Setup.ipynb as the first notebook in the official KSO2 pipeline (00–05). Creates a project via ProjectManager, attaches a YOLO dataset (user-provided or built-in COCO8 sample), optional offline augmentation, and a ready check before training.

Placement note: placed at notebooks/01_Project_Setup.ipynb (top-level, flat numbered pipeline as discussed with @trossi ) as opposed to the current module-named folders. I'll make a follow-up PR to reorganize the rest. Should look like so at the end

notebooks/
├── 00_Data_Preparation.ipynb          ->  (in dev)
**├── 01_Project_Setup.ipynb                  **← this PR****
├── 02_Train_and_Eval_Models.ipynb      -> (rename of standalone Train+Eval)
├── 03_Inference.ipynb                 ->  (rename of standalone Model_Inference)
├── 04_Analysis.ipynb                    -> (planned)
├── 05_Publish_Models.ipynb       -> (planned)
├── standalone/                          (transitional, current standalones in kso/notebooks/)
└── demos/                                (renamed from kso_demo_notebooks/, @GhaithChaabane and I can keep trialling/adding new features in these first)